### PR TITLE
async db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - nightly
 
 before_script: |
-  rustup component add rustfmt-preview &&
+  rustup component add rustfmt-preview
 script: |
   cargo fmt -- --check &&
   cargo build --verbose &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ rust:
 
 before_script: |
   rustup component add rustfmt-preview &&
-  cargo install clippy -f
 script: |
   cargo fmt -- --check &&
-  cargo clippy -- -D clippy &&
   cargo build --verbose &&
   cargo test  --verbose
 cache: cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ edition = "2018"
 parking_lot = "0.6.3"
 
 [dev-dependencies]
+runtime = "0.3.0-alpha.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ documentation = "https://docs.rs/memdb"
 description = "Thread-safe in-memory key-value store"
 authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
-failure = "0.1.2"
 parking_lot = "0.6.3"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -10,30 +10,11 @@ Does not persist to disk.
 
 ## Usage
 ```rust
-extern crate memdb;
-
-use memdb::Memdb;
-
-let mut db = Memdb::default();
-db.set("beep".into(), "boop".into());
-
-let val = db.get("beep".into());
-assert_eq!(val, Some("boop".to_string()));
-```
-
-### Usage In Threads
-To use the database inside a thread, call `.clone()` on it and `move` the
-result.
-
-```rust
-let db = Memdb::default();
-
-let mut db_handle = db.clone();
-let t = thread::spawn(move || {
-  db_handle.set("beep".into(), "boop".into());
-});
-
-t.join().unwrap();
+let mut db = Memdb::open().await?;
+db.set("beep", "boop").await?;
+let val = db.get("beep").await?;
+assert_eq!(val, Some("boop".as_bytes().to_owned()));
+Ok(())
 ```
 
 ## Installation

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-max_width = 80
-tab_spaces = 2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,47 +3,44 @@
 use parking_lot::RwLock;
 
 use std::collections::HashMap;
-use std::hash::Hash;
 use std::sync::Arc;
 
 /// Key-value database.
 #[derive(Debug, Clone)]
-pub struct Memdb<K: Hash + Eq, V> {
-    hashmap: Arc<RwLock<HashMap<K, V>>>,
+pub struct Memdb {
+    hashmap: Arc<RwLock<HashMap<Vec<u8>, Vec<u8>>>>,
 }
 
-impl<K, V> Memdb<K, V>
-where
-    K: Eq + Hash,
-    V: Clone,
-{
+impl Memdb {
     /// Create a new instance.
     #[inline]
     pub async fn open() -> Self {
         Self {
-            hashmap: Arc::new(RwLock::new(HashMap::<K, V>::new())),
+            hashmap: Arc::new(RwLock::new(HashMap::<Vec<u8>, Vec<u8>>::new())),
         }
     }
 
     /// Set a value in the database.
     #[inline]
-    pub async fn set(&mut self, key: K, value: V) -> Option<V> {
+    pub async fn set(&mut self, key: impl AsRef<[u8]>, value: impl AsRef<[u8]>) -> Option<Vec<u8>> {
         let hashmap = self.hashmap.clone();
         let mut hashmap = hashmap.write();
-        hashmap.insert(key, value)
+        hashmap.insert(key.as_ref().to_owned(), value.as_ref().to_owned())
     }
 
     /// Get a value from the database.
     #[must_use]
     #[inline]
-    pub async fn get(&self, key: K) -> Option<V> {
+    pub async fn get(&self, key: impl AsRef<[u8]>) -> Option<Vec<u8>> {
+        let key = key.as_ref().to_owned();
         let hashmap = &self.hashmap.read();
         hashmap.get(&key).cloned()
     }
 
     /// Delete a value from the database.
     #[inline]
-    pub async fn del(&mut self, key: K) -> Option<V> {
+    pub async fn del(&mut self, key: impl AsRef<[u8]>) -> Option<Vec<u8>> {
+        let key = key.as_ref().to_owned();
         let hashmap = &mut self.hashmap.write();
         hashmap.remove(&key)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,4 @@
-#![cfg_attr(feature = "nightly", deny(missing_docs))]
-#![cfg_attr(feature = "nightly", feature(external_doc))]
-#![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
-#![cfg_attr(test, deny(warnings))]
-
-extern crate parking_lot;
+#![feature(async_await)]
 
 use parking_lot::RwLock;
 
@@ -14,51 +9,42 @@ use std::sync::Arc;
 /// Key-value database.
 #[derive(Debug, Clone)]
 pub struct Memdb<K: Hash + Eq, V> {
-  hashmap: Arc<RwLock<HashMap<K, V>>>,
+    hashmap: Arc<RwLock<HashMap<K, V>>>,
 }
 
 impl<K, V> Memdb<K, V>
 where
-  K: Eq + Hash,
-  V: Clone,
+    K: Eq + Hash,
+    V: Clone,
 {
-  /// Create a new instance.
-  #[inline]
-  pub fn new() -> Self {
-    Self {
-      hashmap: Arc::new(RwLock::new(HashMap::<K, V>::new())),
+    /// Create a new instance.
+    #[inline]
+    pub async fn open() -> Self {
+        Self {
+            hashmap: Arc::new(RwLock::new(HashMap::<K, V>::new())),
+        }
     }
-  }
 
-  /// Set a value in the database.
-  #[inline]
-  pub fn set(&mut self, key: K, value: V) -> Option<V> {
-    let hashmap = self.hashmap.clone();
-    let mut hashmap = hashmap.write();
-    hashmap.insert(key, value)
-  }
-
-  /// Get a value from the database.
-  #[must_use]
-  #[inline]
-  pub fn get(&self, key: K) -> Option<V> {
-    let hashmap = &self.hashmap.read();
-    hashmap.get(&key).cloned()
-  }
-
-  /// Delete a value from the database.
-  #[inline]
-  pub fn del(&mut self, key: K) -> Option<V> {
-    let hashmap = &mut self.hashmap.write();
-    hashmap.remove(&key)
-  }
-}
-
-impl Default for Memdb<String, String> {
-  #[inline]
-  fn default() -> Self {
-    Self {
-      hashmap: Arc::new(RwLock::new(HashMap::<String, String>::new())),
+    /// Set a value in the database.
+    #[inline]
+    pub async fn set(&mut self, key: K, value: V) -> Option<V> {
+        let hashmap = self.hashmap.clone();
+        let mut hashmap = hashmap.write();
+        hashmap.insert(key, value)
     }
-  }
+
+    /// Get a value from the database.
+    #[must_use]
+    #[inline]
+    pub async fn get(&self, key: K) -> Option<V> {
+        let hashmap = &self.hashmap.read();
+        hashmap.get(&key).cloned()
+    }
+
+    /// Delete a value from the database.
+    #[inline]
+    pub async fn del(&mut self, key: K) -> Option<V> {
+        let hashmap = &mut self.hashmap.write();
+        hashmap.remove(&key)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,26 @@
 #![feature(async_await)]
 
+//! Thread-safe in-memory key-value store. Ideal for development and prototyping.
+//! Does not persist to disk.
+//!
+//! ## Examples
+//!
+//! ```
+//! # #![feature(async_await)]
+//! # #[runtime::main]
+//! # async fn main() -> std::io::Result<()> {
+//! let mut db = memdb::Memdb::open().await?;
+//! db.set("beep", "boop").await?;
+//! let val = db.get("beep").await?;
+//! assert_eq!(val, Some("boop".as_bytes().to_owned()));
+//! # Ok(())
+//! # }
+//! ```
+
 use parking_lot::RwLock;
 
 use std::collections::HashMap;
+use std::io;
 use std::sync::Arc;
 
 /// Key-value database.
@@ -14,34 +32,38 @@ pub struct Memdb {
 impl Memdb {
     /// Create a new instance.
     #[inline]
-    pub async fn open() -> Self {
-        Self {
+    pub async fn open() -> io::Result<Self> {
+        Ok(Self {
             hashmap: Arc::new(RwLock::new(HashMap::<Vec<u8>, Vec<u8>>::new())),
-        }
+        })
     }
 
     /// Set a value in the database.
     #[inline]
-    pub async fn set(&mut self, key: impl AsRef<[u8]>, value: impl AsRef<[u8]>) -> Option<Vec<u8>> {
+    pub async fn set(
+        &mut self,
+        key: impl AsRef<[u8]>,
+        value: impl AsRef<[u8]>,
+    ) -> io::Result<Option<Vec<u8>>> {
         let hashmap = self.hashmap.clone();
         let mut hashmap = hashmap.write();
-        hashmap.insert(key.as_ref().to_owned(), value.as_ref().to_owned())
+        Ok(hashmap.insert(key.as_ref().to_owned(), value.as_ref().to_owned()))
     }
 
     /// Get a value from the database.
     #[must_use]
     #[inline]
-    pub async fn get(&self, key: impl AsRef<[u8]>) -> Option<Vec<u8>> {
+    pub async fn get(&self, key: impl AsRef<[u8]>) -> io::Result<Option<Vec<u8>>> {
         let key = key.as_ref().to_owned();
         let hashmap = &self.hashmap.read();
-        hashmap.get(&key).cloned()
+        Ok(hashmap.get(&key).cloned())
     }
 
     /// Delete a value from the database.
     #[inline]
-    pub async fn del(&mut self, key: impl AsRef<[u8]>) -> Option<Vec<u8>> {
+    pub async fn del(&mut self, key: impl AsRef<[u8]>) -> io::Result<Option<Vec<u8>>> {
         let key = key.as_ref().to_owned();
         let hashmap = &mut self.hashmap.write();
-        hashmap.remove(&key)
+        Ok(hashmap.remove(&key))
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -17,10 +17,12 @@ async fn threaded_set_get() {
     let mut handle = db.clone();
     runtime::spawn(async move {
         handle.set("beep", "boop").await;
-        let mut handle = db.clone();
         runtime::spawn(async move {
-            let val = db.get("beep").await;
+            let handle = handle.clone();
+            let val = handle.get("beep").await;
             assert_eq!(val, Some("boop".as_bytes().to_owned()));
-        }).await;
-    }).await;
+        })
+        .await;
+    })
+    .await;
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,28 +1,34 @@
 #![feature(async_await)]
 
 use memdb::Memdb;
+use std::error;
+use std::io;
 
 #[runtime::test]
-async fn set_get() {
-    let mut db = Memdb::open().await;
-    db.set("beep", "boop").await;
-    let val = db.get("beep").await;
+async fn set_get() -> io::Result<()> {
+    let mut db = Memdb::open().await?;
+    db.set("beep", "boop").await?;
+    let val = db.get("beep").await?;
     assert_eq!(val, Some("boop".as_bytes().to_owned()));
+    Ok(())
 }
 
 #[runtime::test]
-async fn threaded_set_get() {
-    let db = Memdb::open().await;
+async fn threaded_set_get() -> io::Result<()> {
+    let db = Memdb::open().await?;
 
     let mut handle = db.clone();
     runtime::spawn(async move {
-        handle.set("beep", "boop").await;
+        handle.set("beep", "boop").await?;
         runtime::spawn(async move {
             let handle = handle.clone();
-            let val = handle.get("beep").await;
+            let val = handle.get("beep").await?;
             assert_eq!(val, Some("boop".as_bytes().to_owned()));
+            Ok::<(), std::io::Error>(())
         })
-        .await;
+        .await?;
+        Ok::<(), std::io::Error>(())
     })
-    .await;
+    .await?;
+    Ok::<(), std::io::Error>(())
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,6 @@
 #![feature(async_await)]
 
 use memdb::Memdb;
-use std::thread;
 
 #[runtime::test]
 async fn set_get() {
@@ -16,13 +15,12 @@ async fn threaded_set_get() {
     let db = Memdb::open().await;
 
     let mut handle = db.clone();
-    let setter = runtime::spawn(async {
+    runtime::spawn(async move {
         handle.set("beep", "boop").await;
-
-        let handle = db.clone();
-        runtime::spawn(async {
-            let val = handle.get("beep").await;
+        let mut handle = db.clone();
+        runtime::spawn(async move {
+            let val = db.get("beep").await;
             assert_eq!(val, Some("boop".as_bytes().to_owned()));
         }).await;
-    });
+    }).await;
 }


### PR DESCRIPTION
- run rustfmt
- makes all our methods async to better emulate real-world use
- which meant we had to remove the `Default` impl